### PR TITLE
[ca] add certificate authority tool

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,7 @@
 name: Go
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
     paths:
@@ -57,3 +58,9 @@ jobs:
       # step 4: run test
       - name: Run coverage
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      # step 5: upload coverage
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v4
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,21 @@ before:
     - go generate ./...
 
 builds:
-  - main: ./cmd/smsgate
+  - id: smsgate
+    main: ./cmd/smsgate
+    binary: smsgate
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+  - id: smsgate-ca
+    main: ./cmd/smsgate-ca
+    binary: smsgate-ca
     env:
       - CGO_ENABLED=0
     goos:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -5,6 +5,7 @@ WORKDIR /app
 
 # Copy the Pre-built binary file from GoReleaser
 COPY smsgate .
+COPY smsgate-ca .
 
 # Command to run the executable
 ENTRYPOINT ["./smsgate"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A command-line interface for interacting with the SMS Gateway for Android API.
 
+There are two CLI tools in this repository: `smsgate` and `smsgate-ca`. The first one is for SMS Gateway for Android itself, and the second one is for the Certificate Authority.
+
 ## Table of Contents
 
 - [SMS Gateway for Android™ CLI](#sms-gateway-for-android-cli)

--- a/cmd/smsgate-ca/smsgate-ca.go
+++ b/cmd/smsgate-ca/smsgate-ca.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/android-sms-gateway/cli/internal/commands/ca"
+	"github.com/android-sms-gateway/cli/internal/core/codes"
+	"github.com/android-sms-gateway/cli/internal/utils/metadata"
+	client "github.com/android-sms-gateway/client-go/ca"
+	"github.com/joho/godotenv"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	version = "0.0.0"
+)
+
+func main() {
+	if err := godotenv.Load(); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error loading .env file: %v\n", err)
+		os.Exit(codes.ParamsError)
+	}
+
+	app := &cli.App{
+		Name:     "smsgate-ca",
+		Usage:    "CLI interface for interacting with Certificate Authority of SMS Gateway for Android™",
+		Version:  version,
+		Commands: make([]*cli.Command, 0, len(ca.Commands)),
+		Authors: []*cli.Author{
+			{
+				Name:  "Aleksandr Soloshenko",
+				Email: "support@sms-gate.app",
+			},
+		},
+		Before: func(c *cli.Context) error {
+			c.App.Metadata[metadata.CAClientKey] = client.NewClient()
+			return nil
+		},
+	}
+
+	app.Commands = append(app.Commands, ca.Commands...)
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(codes.ParamsError)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/android-sms-gateway/cli
 go 1.23.2
 
 require (
-	github.com/android-sms-gateway/client-go v1.4.0
+	github.com/android-sms-gateway/client-go v1.5.0
 	github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3
 	github.com/joho/godotenv v1.5.1
 	github.com/urfave/cli/v2 v2.27.5

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
-github.com/android-sms-gateway/client-go v1.1.0 h1:mAPsueRrY/qOdQAU5yO3uLQAb7Po+3jBxB1tiqyClvg=
-github.com/android-sms-gateway/client-go v1.1.0/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
-github.com/android-sms-gateway/client-go v1.3.1-0.20250129225754-59c34aa9d1c0 h1:OQgfNIUB32Ui1plEtfjjRAP85fpW8gBQgc69g5IAimI=
-github.com/android-sms-gateway/client-go v1.3.1-0.20250129225754-59c34aa9d1c0/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
-github.com/android-sms-gateway/client-go v1.4.0 h1:yc6VqbiF1p/a0Ygw49VrKYHwcBJQIidcBz4C30jb27Q=
-github.com/android-sms-gateway/client-go v1.4.0/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.4.1-0.20250131044630-1de6b5ecb49f h1:7qhIHF6Kytfa1ln0ww46nJIFwxzHkINK7atkE8cLSJM=
+github.com/android-sms-gateway/client-go v1.4.1-0.20250131044630-1de6b5ecb49f/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.5.0 h1:CDREtWU2Z85dW7JcsW3a+vKZkj9g2Buq8vlrnEdGaoE=
+github.com/android-sms-gateway/client-go v1.5.0/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3 h1:mq9rmBMCCzqGnZtbQqFSd+Ua3fahqUOYaTf26YFhWJc=
 github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3/go.mod h1:WDqc7HZNqHxUTisArkYIBZtqUfJBVyPWeQI+FMwEzAw=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=

--- a/internal/commands/ca/ca.go
+++ b/internal/commands/ca/ca.go
@@ -1,0 +1,9 @@
+package ca
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var Commands = []*cli.Command{
+	webhooks,
+}

--- a/internal/commands/ca/webhooks.go
+++ b/internal/commands/ca/webhooks.go
@@ -1,0 +1,146 @@
+package ca
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"net"
+	"net/netip"
+	"os"
+	"time"
+
+	"github.com/android-sms-gateway/cli/internal/core/codes"
+	"github.com/android-sms-gateway/cli/internal/utils/metadata"
+	"github.com/android-sms-gateway/client-go/ca"
+	"github.com/urfave/cli/v2"
+)
+
+var webhooks = &cli.Command{
+	Name:      "webhooks",
+	Aliases:   []string{"wh"},
+	Usage:     "Issue a new certificate for receiving webhooks to local IP address",
+	Args:      true,
+	ArgsUsage: "IP address",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "out",
+			Usage:    "Certificate output file",
+			Required: false,
+			Value:    "server.crt",
+		},
+		&cli.StringFlag{
+			Name:     "keyout",
+			Usage:    "Private key output file",
+			Required: false,
+			Value:    "server.key",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		ip := c.Args().Get(0)
+		if ip == "" {
+			return cli.Exit("IP address is empty", codes.ParamsError)
+		}
+
+		netipAddr, err := netip.ParseAddr(ip)
+		if err != nil {
+			return cli.Exit(err.Error(), codes.ParamsError)
+		}
+
+		if !netipAddr.IsPrivate() {
+			return cli.Exit("IP address is not private", codes.ParamsError)
+		}
+
+		log.Println("Generating private key...")
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("Failed to generate private key: %s", err.Error()), codes.InternalError)
+		}
+
+		privBytes, err := x509.MarshalECPrivateKey(priv)
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("Failed to marshal private key: %s", err.Error()), codes.InternalError)
+		}
+
+		privPemBytes := pem.EncodeToMemory(&pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: privBytes,
+		})
+
+		subject := pkix.Name{
+			CommonName: netipAddr.String(),
+		}
+
+		csrTemplate := x509.CertificateRequest{
+			Subject:            subject,
+			SignatureAlgorithm: x509.ECDSAWithSHA256,
+			// Key Usage: nonRepudiation, digitalSignature, keyEncipherment
+			ExtraExtensions: []pkix.Extension{
+				{
+					Id:       []int{2, 5, 29, 15}, // keyUsage OID
+					Critical: true,
+					Value:    []byte{0x03, 0x02, 0x05, 0xa0}, // nonRepudiation, digitalSignature, keyEncipherment
+				},
+				{
+					Id:       []int{2, 5, 29, 37}, // extendedKeyUsage OID
+					Critical: false,
+					Value:    []byte{0x30, 0x06, 0x06, 0x04, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x01}, // serverAuth
+				},
+			},
+			IPAddresses: []net.IP{netipAddr.AsSlice()},
+		}
+
+		log.Println("Creating certificate request...")
+		csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, priv)
+		if err != nil {
+			return cli.Exit(fmt.Sprintf("Failed to create certificate request: %s", err.Error()), codes.InternalError)
+		}
+
+		csrPemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+
+		client := metadata.GetCAClient(c.App.Metadata)
+
+		log.Println("Sending certificate request...")
+		resp, err := client.PostCSR(c.Context, ca.PostCSRRequest{
+			Content: string(csrPemBytes),
+		})
+		if err != nil {
+			return cli.Exit(err.Error(), codes.ClientError)
+		}
+
+		timeout := time.After(30 * time.Second)
+		for resp.Certificate == "" {
+			select {
+			case <-c.Context.Done():
+				return cli.Exit("Cancelled", codes.ClientError)
+			case <-timeout:
+				return cli.Exit("Timeout waiting for certificate", codes.ClientError)
+			case <-time.After(1 * time.Second):
+			}
+
+			log.Println("Waiting for certificate response...")
+			resp, err = client.GetCSRStatus(c.Context, resp.RequestID)
+			if err != nil {
+				return cli.Exit(err.Error(), codes.ClientError)
+			}
+		}
+
+		log.Println("Saving certificate...")
+		if err := os.WriteFile(c.String("out"), []byte(resp.Certificate), 0644); err != nil {
+			return cli.Exit(err.Error(), codes.OutputError)
+		}
+		if err := os.WriteFile(c.String("keyout"), privPemBytes, 0400); err != nil {
+			os.Remove(c.String("out"))
+			return cli.Exit(err.Error(), codes.OutputError)
+		}
+
+		log.Printf("Certificate saved to %s\n", c.String("out"))
+		log.Printf("Private key saved to %s\n", c.String("keyout"))
+
+		return nil
+	},
+}

--- a/internal/core/codes/codes.go
+++ b/internal/core/codes/codes.go
@@ -5,4 +5,5 @@ const (
 	ParamsError
 	ClientError
 	OutputError
+	InternalError
 )

--- a/internal/utils/metadata/metadata.go
+++ b/internal/utils/metadata/metadata.go
@@ -2,16 +2,22 @@ package metadata
 
 import (
 	"github.com/android-sms-gateway/cli/internal/core/output"
+	"github.com/android-sms-gateway/client-go/ca"
 	"github.com/android-sms-gateway/client-go/smsgateway"
 )
 
 const (
 	ClientKey   = "client"
+	CAClientKey = "caclient"
 	RendererKey = "renderer"
 )
 
 func GetClient(metadata map[string]any) *smsgateway.Client {
 	return metadata[ClientKey].(*smsgateway.Client)
+}
+
+func GetCAClient(metadata map[string]any) *ca.Client {
+	return metadata[CAClientKey].(*ca.Client)
 }
 
 func GetRenderer(metadata map[string]any) output.Renderer {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced two CLI tools: `smsgate` and `smsgate-ca`
  - Added manual workflow dispatch for GitHub Actions
  - Implemented Certificate Authority (CA) functionality for webhook certificate generation
  - Added support for error handling with a new `InternalError` type

- **Documentation**
  - Updated README with descriptions of CLI tools

- **Chores**
  - Updated dependency version for `github.com/android-sms-gateway/client-go`
  - Enhanced build configuration in GoReleaser
  - Modified Dockerfile to include additional binary

- **Infrastructure**
  - Added new error handling and metadata management utilities
  - Introduced a new function for retrieving the CA client from metadata
  - Added a new command for issuing certificates for webhooks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->