### PR TITLE
[ca] add Private Server certificate support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/android-sms-gateway/cli
 go 1.23.2
 
 require (
-	github.com/android-sms-gateway/client-go v1.5.0
+	github.com/android-sms-gateway/client-go v1.5.5-0.20250309004612-ebfc247ebb13
 	github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3
 	github.com/joho/godotenv v1.5.1
 	github.com/urfave/cli/v2 v2.27.5

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/android-sms-gateway/cli
 go 1.23.2
 
 require (
-	github.com/android-sms-gateway/client-go v1.5.5-0.20250309004612-ebfc247ebb13
+	github.com/android-sms-gateway/client-go v1.5.5
 	github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3
 	github.com/joho/godotenv v1.5.1
 	github.com/urfave/cli/v2 v2.27.5

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,7 @@
-github.com/android-sms-gateway/client-go v1.4.1-0.20250131044630-1de6b5ecb49f h1:7qhIHF6Kytfa1ln0ww46nJIFwxzHkINK7atkE8cLSJM=
-github.com/android-sms-gateway/client-go v1.4.1-0.20250131044630-1de6b5ecb49f/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
-github.com/android-sms-gateway/client-go v1.5.0 h1:CDREtWU2Z85dW7JcsW3a+vKZkj9g2Buq8vlrnEdGaoE=
-github.com/android-sms-gateway/client-go v1.5.0/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
-github.com/android-sms-gateway/client-go v1.5.5-0.20250307091924-1076d115eb88 h1:LmcJ8zpxKTHtwBLkQcmn1pEIgPEDCH5bY9ukYQAf+1c=
-github.com/android-sms-gateway/client-go v1.5.5-0.20250307091924-1076d115eb88/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/android-sms-gateway/client-go v1.5.5-0.20250309004612-ebfc247ebb13 h1:OSPmpOeLtU10zULCNuSJ6ouuwlKZlBaxYEs5vxknPWI=
 github.com/android-sms-gateway/client-go v1.5.5-0.20250309004612-ebfc247ebb13/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.5.5 h1:38ykCT1g+w3dW7ZNDeX1qyfZuvXI5h19MP/WFg4Rodw=
+github.com/android-sms-gateway/client-go v1.5.5/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3 h1:mq9rmBMCCzqGnZtbQqFSd+Ua3fahqUOYaTf26YFhWJc=
 github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3/go.mod h1:WDqc7HZNqHxUTisArkYIBZtqUfJBVyPWeQI+FMwEzAw=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/android-sms-gateway/client-go v1.4.1-0.20250131044630-1de6b5ecb49f h1
 github.com/android-sms-gateway/client-go v1.4.1-0.20250131044630-1de6b5ecb49f/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/android-sms-gateway/client-go v1.5.0 h1:CDREtWU2Z85dW7JcsW3a+vKZkj9g2Buq8vlrnEdGaoE=
 github.com/android-sms-gateway/client-go v1.5.0/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.5.5-0.20250307091924-1076d115eb88 h1:LmcJ8zpxKTHtwBLkQcmn1pEIgPEDCH5bY9ukYQAf+1c=
+github.com/android-sms-gateway/client-go v1.5.5-0.20250307091924-1076d115eb88/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.5.5-0.20250309004612-ebfc247ebb13 h1:OSPmpOeLtU10zULCNuSJ6ouuwlKZlBaxYEs5vxknPWI=
+github.com/android-sms-gateway/client-go v1.5.5-0.20250309004612-ebfc247ebb13/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3 h1:mq9rmBMCCzqGnZtbQqFSd+Ua3fahqUOYaTf26YFhWJc=
 github.com/capcom6/go-helpers v0.0.0-20240521035631-865ee2879fa3/go.mod h1:WDqc7HZNqHxUTisArkYIBZtqUfJBVyPWeQI+FMwEzAw=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=

--- a/internal/commands/ca/ca.go
+++ b/internal/commands/ca/ca.go
@@ -6,4 +6,5 @@ import (
 
 var Commands = []*cli.Command{
 	webhooks,
+	private,
 }

--- a/internal/commands/ca/common/command.go
+++ b/internal/commands/ca/common/command.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net"
+	"net/netip"
+
+	"github.com/android-sms-gateway/cli/internal/core/codes"
+	"github.com/android-sms-gateway/client-go/ca"
+	"github.com/urfave/cli/v2"
+)
+
+// NewIPCertificateCommand creates a new CLI command for generating an IP certificate
+// of the specified type
+func NewIPCertificateCommand(name, usage string, aliases []string, typ ca.CSRType) *cli.Command {
+	return &cli.Command{
+		Name:      name,
+		Aliases:   aliases,
+		Usage:     usage,
+		Args:      true,
+		ArgsUsage: "Server IP address",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "out",
+				Usage:    "Certificate output file",
+				Required: false,
+				Value:    "server.crt",
+			},
+			&cli.StringFlag{
+				Name:     "keyout",
+				Usage:    "Private key output file",
+				Required: false,
+				Value:    "server.key",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			ip := c.Args().Get(0)
+			if ip == "" {
+				return cli.Exit("IP address is empty", codes.ParamsError)
+			}
+
+			netipAddr, err := netip.ParseAddr(ip)
+			if err != nil {
+				return cli.Exit(err.Error(), codes.ParamsError)
+			}
+
+			if !netipAddr.IsPrivate() {
+				return cli.Exit("IP address is not private", codes.ParamsError)
+			}
+
+			csrTemplate := x509.CertificateRequest{
+				Subject: pkix.Name{
+					CommonName: netipAddr.String(),
+				},
+				IPAddresses: []net.IP{netipAddr.AsSlice()},
+			}
+
+			return requestCertificate(c, typ, csrTemplate)
+		},
+	}
+
+}

--- a/internal/commands/ca/common/utils.go
+++ b/internal/commands/ca/common/utils.go
@@ -1,4 +1,4 @@
-package ca
+package common
 
 import (
 	"crypto/ecdsa"
@@ -41,7 +41,7 @@ func newServerCertificateRequestPEM(template x509.CertificateRequest, priv *ecds
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes}), nil
 }
 
-func requestCertificate(c *cli.Context, template x509.CertificateRequest) error {
+func requestCertificate(c *cli.Context, typ ca.CSRType, template x509.CertificateRequest) error {
 	log.Println("Generating private key...")
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -68,6 +68,7 @@ func requestCertificate(c *cli.Context, template x509.CertificateRequest) error 
 	client := metadata.GetCAClient(c.App.Metadata)
 
 	resp, err := client.PostCSR(c.Context, ca.PostCSRRequest{
+		Type:    typ,
 		Content: string(csrPemBytes),
 	})
 	if err != nil {

--- a/internal/commands/ca/private.go
+++ b/internal/commands/ca/private.go
@@ -1,0 +1,13 @@
+package ca
+
+import (
+	"github.com/android-sms-gateway/cli/internal/commands/ca/common"
+	"github.com/android-sms-gateway/client-go/ca"
+)
+
+var private = common.NewIPCertificateCommand(
+	"private",
+	"Issue a new certificate for Private server",
+	[]string{"p"},
+	ca.CSRTypePrivateServer,
+)

--- a/internal/commands/ca/utils.go
+++ b/internal/commands/ca/utils.go
@@ -1,0 +1,107 @@
+package ca
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/android-sms-gateway/cli/internal/core/codes"
+	"github.com/android-sms-gateway/cli/internal/utils/metadata"
+	"github.com/android-sms-gateway/client-go/ca"
+	"github.com/urfave/cli/v2"
+)
+
+func newServerCertificateRequestPEM(template x509.CertificateRequest, priv *ecdsa.PrivateKey) ([]byte, error) {
+	template.SignatureAlgorithm = x509.ECDSAWithSHA256
+	template.ExtraExtensions = []pkix.Extension{
+		{
+			Id:       []int{2, 5, 29, 15}, // keyUsage OID
+			Critical: true,
+			Value:    []byte{0x03, 0x02, 0x05, 0xa0}, // nonRepudiation, digitalSignature, keyEncipherment
+		},
+		{
+			Id:       []int{2, 5, 29, 37}, // extendedKeyUsage OID
+			Critical: false,
+			Value:    []byte{0x30, 0x06, 0x06, 0x04, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x01}, // serverAuth
+		},
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, priv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate request: %w", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes}), nil
+}
+
+func requestCertificate(c *cli.Context, template x509.CertificateRequest) error {
+	log.Println("Generating private key...")
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("Failed to generate private key: %s", err.Error()), codes.InternalError)
+	}
+
+	privBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return cli.Exit(fmt.Sprintf("Failed to marshal private key: %s", err.Error()), codes.InternalError)
+	}
+
+	privPemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: privBytes,
+	})
+
+	log.Println("Creating certificate request...")
+	csrPemBytes, err := newServerCertificateRequestPEM(template, priv)
+	if err != nil {
+		return cli.Exit(err.Error(), codes.InternalError)
+	}
+
+	log.Println("Sending certificate request...")
+	client := metadata.GetCAClient(c.App.Metadata)
+
+	resp, err := client.PostCSR(c.Context, ca.PostCSRRequest{
+		Content: string(csrPemBytes),
+	})
+	if err != nil {
+		return cli.Exit(err.Error(), codes.ClientError)
+	}
+
+	timeout := time.After(30 * time.Second)
+	for resp.Certificate == "" {
+		select {
+		case <-c.Context.Done():
+			return cli.Exit("Cancelled", codes.ClientError)
+		case <-timeout:
+			return cli.Exit("Timeout waiting for certificate", codes.ClientError)
+		case <-time.After(1 * time.Second):
+		}
+
+		log.Println("Waiting for certificate response...")
+		resp, err = client.GetCSRStatus(c.Context, resp.RequestID)
+		if err != nil {
+			return cli.Exit(err.Error(), codes.ClientError)
+		}
+	}
+
+	log.Println("Saving certificate...")
+	if err := os.WriteFile(c.String("out"), []byte(resp.Certificate), 0644); err != nil {
+		return cli.Exit(err.Error(), codes.OutputError)
+	}
+	if err := os.WriteFile(c.String("keyout"), privPemBytes, 0400); err != nil {
+		os.Remove(c.String("out"))
+		return cli.Exit(err.Error(), codes.OutputError)
+	}
+
+	log.Printf("Certificate saved to %s\n", c.String("out"))
+	log.Printf("Private key saved to %s\n", c.String("keyout"))
+
+	return nil
+}

--- a/internal/commands/ca/webhooks.go
+++ b/internal/commands/ca/webhooks.go
@@ -1,57 +1,13 @@
 package ca
 
 import (
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"net"
-	"net/netip"
-
-	"github.com/android-sms-gateway/cli/internal/core/codes"
-	"github.com/urfave/cli/v2"
+	"github.com/android-sms-gateway/cli/internal/commands/ca/common"
+	"github.com/android-sms-gateway/client-go/ca"
 )
 
-var webhooks = &cli.Command{
-	Name:      "webhooks",
-	Aliases:   []string{"wh"},
-	Usage:     "Issue a new certificate for receiving webhooks to local IP address",
-	Args:      true,
-	ArgsUsage: "IP address",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:     "out",
-			Usage:    "Certificate output file",
-			Required: false,
-			Value:    "server.crt",
-		},
-		&cli.StringFlag{
-			Name:     "keyout",
-			Usage:    "Private key output file",
-			Required: false,
-			Value:    "server.key",
-		},
-	},
-	Action: func(c *cli.Context) error {
-		ip := c.Args().Get(0)
-		if ip == "" {
-			return cli.Exit("IP address is empty", codes.ParamsError)
-		}
-
-		netipAddr, err := netip.ParseAddr(ip)
-		if err != nil {
-			return cli.Exit(err.Error(), codes.ParamsError)
-		}
-
-		if !netipAddr.IsPrivate() {
-			return cli.Exit("IP address is not private", codes.ParamsError)
-		}
-
-		csrTemplate := x509.CertificateRequest{
-			Subject: pkix.Name{
-				CommonName: netipAddr.String(),
-			},
-			IPAddresses: []net.IP{netipAddr.AsSlice()},
-		}
-
-		return requestCertificate(c, csrTemplate)
-	},
-}
+var webhooks = common.NewIPCertificateCommand(
+	"webhooks",
+	"Issue a new certificate for receiving webhooks to local IP address",
+	[]string{"wh"},
+	ca.CSRTypeWebhook,
+)

--- a/internal/commands/ca/webhooks.go
+++ b/internal/commands/ca/webhooks.go
@@ -1,22 +1,12 @@
 package ca
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
-	"fmt"
-	"log"
 	"net"
 	"net/netip"
-	"os"
-	"time"
 
 	"github.com/android-sms-gateway/cli/internal/core/codes"
-	"github.com/android-sms-gateway/cli/internal/utils/metadata"
-	"github.com/android-sms-gateway/client-go/ca"
 	"github.com/urfave/cli/v2"
 )
 
@@ -55,92 +45,13 @@ var webhooks = &cli.Command{
 			return cli.Exit("IP address is not private", codes.ParamsError)
 		}
 
-		log.Println("Generating private key...")
-		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		if err != nil {
-			return cli.Exit(fmt.Sprintf("Failed to generate private key: %s", err.Error()), codes.InternalError)
-		}
-
-		privBytes, err := x509.MarshalECPrivateKey(priv)
-		if err != nil {
-			return cli.Exit(fmt.Sprintf("Failed to marshal private key: %s", err.Error()), codes.InternalError)
-		}
-
-		privPemBytes := pem.EncodeToMemory(&pem.Block{
-			Type:  "EC PRIVATE KEY",
-			Bytes: privBytes,
-		})
-
-		subject := pkix.Name{
-			CommonName: netipAddr.String(),
-		}
-
 		csrTemplate := x509.CertificateRequest{
-			Subject:            subject,
-			SignatureAlgorithm: x509.ECDSAWithSHA256,
-			// Key Usage: nonRepudiation, digitalSignature, keyEncipherment
-			ExtraExtensions: []pkix.Extension{
-				{
-					Id:       []int{2, 5, 29, 15}, // keyUsage OID
-					Critical: true,
-					Value:    []byte{0x03, 0x02, 0x05, 0xa0}, // nonRepudiation, digitalSignature, keyEncipherment
-				},
-				{
-					Id:       []int{2, 5, 29, 37}, // extendedKeyUsage OID
-					Critical: false,
-					Value:    []byte{0x30, 0x06, 0x06, 0x04, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, 0x01}, // serverAuth
-				},
+			Subject: pkix.Name{
+				CommonName: netipAddr.String(),
 			},
 			IPAddresses: []net.IP{netipAddr.AsSlice()},
 		}
 
-		log.Println("Creating certificate request...")
-		csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, priv)
-		if err != nil {
-			return cli.Exit(fmt.Sprintf("Failed to create certificate request: %s", err.Error()), codes.InternalError)
-		}
-
-		csrPemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
-
-		client := metadata.GetCAClient(c.App.Metadata)
-
-		log.Println("Sending certificate request...")
-		resp, err := client.PostCSR(c.Context, ca.PostCSRRequest{
-			Content: string(csrPemBytes),
-		})
-		if err != nil {
-			return cli.Exit(err.Error(), codes.ClientError)
-		}
-
-		timeout := time.After(30 * time.Second)
-		for resp.Certificate == "" {
-			select {
-			case <-c.Context.Done():
-				return cli.Exit("Cancelled", codes.ClientError)
-			case <-timeout:
-				return cli.Exit("Timeout waiting for certificate", codes.ClientError)
-			case <-time.After(1 * time.Second):
-			}
-
-			log.Println("Waiting for certificate response...")
-			resp, err = client.GetCSRStatus(c.Context, resp.RequestID)
-			if err != nil {
-				return cli.Exit(err.Error(), codes.ClientError)
-			}
-		}
-
-		log.Println("Saving certificate...")
-		if err := os.WriteFile(c.String("out"), []byte(resp.Certificate), 0644); err != nil {
-			return cli.Exit(err.Error(), codes.OutputError)
-		}
-		if err := os.WriteFile(c.String("keyout"), privPemBytes, 0400); err != nil {
-			os.Remove(c.String("out"))
-			return cli.Exit(err.Error(), codes.OutputError)
-		}
-
-		log.Printf("Certificate saved to %s\n", c.String("out"))
-		log.Printf("Private key saved to %s\n", c.String("keyout"))
-
-		return nil
+		return requestCertificate(c, csrTemplate)
 	},
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command that streamlines issuing certificates for private servers with enhanced IP validation.
  - Added a new command for generating IP certificates, improving the command interface.
- **Refactor**
  - Simplified the certificate issuance workflow, consolidating multiple steps into a unified process.
- **Chores**
  - Upgraded a key dependency to version 1.5.5 to incorporate performance improvements and bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->