### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,9 @@ on:
       - "go.mod"
       - "go.sum"
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/cli/security/code-scanning/1](https://github.com/android-sms-gateway/cli/security/code-scanning/1)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should be added at the root level of the workflow to apply to all jobs, or within each job to define specific permissions for that job. Since the workflow only requires read access to repository contents, we will set `contents: read` as the permission.

The changes will be made to the `.github/workflows/go.yml` file:
1. Add a `permissions` block at the root level of the workflow to apply to all jobs.
2. Alternatively, add a `permissions` block within each job (`golangci` and `test`) to define permissions specific to those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to enhance security for automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->