### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -1,5 +1,8 @@
 name: Discord Release Notification
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [released]


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/cli/security/code-scanning/2](https://github.com/android-sms-gateway/cli/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow to function. Since the workflow only reads repository metadata and does not perform any write operations, we will set `contents: read`. This ensures the workflow has read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for Discord release notifications to ensure proper access to release event data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->