### PR TITLE
[docs] place command after global options

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ smsgate status zXDYfTmTVf3iMd16zzdBj
 Credentials can also be passed via CLI options:
 
 ```bash
-smsgate send -u <username> -p <password> --phones '+12025550123' 'Hello, Dr. Turk!'
+smsgate -u <username> -p <password> send --phones '+12025550123' 'Hello, Dr. Turk!'
 ```
 
 #### Output formats


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage instructions to reflect the new CLI invocation format, placing credentials before the subcommand (e.g., include username and password flags ahead of “send”).
  * Clarified the example to match current behavior while keeping the rest of the flow unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->