### PR TITLE
[output] add table format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ The CLI can be configured using environment variables or command-line flags. You
 
 ### Output Formats
 
-The CLI supports three output formats:
+The CLI supports four output formats:
 
 1. `text`: Human-readable text output (default)
 2. `json`: Pretty printed JSON-formatted output
 3. `raw`: One-line JSON-formatted output
+4. `table`: Tab-aligned columnar output for lists and sub-tables
 
 Please note that when the exit code is not `0`, the error description is printed to stderr without any formatting.
 
@@ -405,6 +406,14 @@ Recipients:
 
 ```json
 {"id":"zXDYfTmTVf3iMd16zzdBj","state":"Pending","isHashed":false,"isEncrypted":false,"recipients":[{"phoneNumber":"+12025550123","state":"Pending"},{"phoneNumber":"+12025550124","state":"Pending"}],"states":{}}
+```
+
+**Table**
+
+```text
+ID                                    EVENT          URL                              DEVICE ID
+123e4567-e89b-12d3-a456-426614174000  sms:received   https://example.com/webhook      dev-abc
+def45678-e89b-12d3-a456-426614174000  sms:sent       https://example.com/other        
 ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/cmd/smsgate/smsgate.go
+++ b/cmd/smsgate/smsgate.go
@@ -77,7 +77,7 @@ func main() {
 			&cli.StringFlag{
 				Name:     "format",
 				Category: categoryOutput,
-				Usage:    "Output format. Supported: text, json, raw",
+				Usage:    "Output format. Supported: text, json, raw, table",
 				Required: false,
 				Value:    string(output.Text),
 				Aliases:  []string{"f"},

--- a/internal/core/output/output.go
+++ b/internal/core/output/output.go
@@ -9,9 +9,10 @@ import (
 type Format string
 
 const (
-	Text Format = "text"
-	JSON Format = "json"
-	RAW  Format = "raw"
+	Text  Format = "text"
+	JSON  Format = "json"
+	RAW   Format = "raw"
+	Table Format = "table"
 )
 
 type Renderer interface {
@@ -21,6 +22,8 @@ type Renderer interface {
 	Webhooks(src []smsgateway.Webhook) (string, error)
 	Success() (string, error)
 }
+
+const EmptyResult = "Empty result"
 
 var ErrUnsupportedFormat = errors.New("unsupported format")
 
@@ -32,6 +35,8 @@ func New(format Format) (Renderer, error) {
 		return NewJSONOutput(), nil
 	case RAW:
 		return NewRawOutput(), nil
+	case Table:
+		return NewTableOutput(), nil
 	default:
 		return nil, ErrUnsupportedFormat
 	}

--- a/internal/core/output/table.go
+++ b/internal/core/output/table.go
@@ -1,0 +1,142 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/android-sms-gateway/client-go/smsgateway"
+)
+
+const tabwriterPadding = 2
+
+type TableOutput struct{}
+
+func NewTableOutput() *TableOutput {
+	return &TableOutput{}
+}
+
+func (*TableOutput) MessageState(src smsgateway.MessageState) (string, error) {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "ID:\t%s\n", src.ID)
+	fmt.Fprintf(&b, "Device ID:\t%s\n", src.DeviceID)
+	fmt.Fprintf(&b, "State:\t%s\n", src.State)
+	fmt.Fprintf(&b, "IsHashed:\t%s\n", boolToString(src.IsHashed))
+	fmt.Fprintf(&b, "IsEncrypted:\t%s\n", boolToString(src.IsEncrypted))
+
+	if len(src.Recipients) > 0 {
+		b.WriteString("\nRecipients:\n")
+		tw := tabwriter.NewWriter(&b, 0, 0, tabwriterPadding, ' ', 0)
+		fmt.Fprintln(tw, "PHONE\tSTATE\tERROR")
+		for _, r := range src.Recipients {
+			errStr := ""
+			if r.Error != nil {
+				errStr = *r.Error
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", r.PhoneNumber, r.State, errStr)
+		}
+		if err := tw.Flush(); err != nil {
+			return "", fmt.Errorf("flush tabwriter: %w", err)
+		}
+	}
+
+	if len(src.States) > 0 {
+		messageStates := []string{
+			string(smsgateway.ProcessingStatePending),
+			string(smsgateway.ProcessingStateProcessed),
+			string(smsgateway.ProcessingStateSent),
+			string(smsgateway.ProcessingStateDelivered),
+			string(smsgateway.ProcessingStateFailed),
+		}
+
+		b.WriteString("\nStates:\n")
+		tw := tabwriter.NewWriter(&b, 0, 0, tabwriterPadding, ' ', 0)
+		fmt.Fprintln(tw, "STATE\tTIME")
+		for _, k := range messageStates {
+			v, ok := src.States[k]
+			if !ok {
+				continue
+			}
+			fmt.Fprintf(tw, "%s\t%s\n", k, v.Local().Format(time.RFC3339))
+		}
+		if err := tw.Flush(); err != nil {
+			return "", fmt.Errorf("flush tabwriter: %w", err)
+		}
+	}
+
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+func (*TableOutput) Logs(src []smsgateway.LogEntry) (string, error) {
+	if len(src) == 0 {
+		return EmptyResult, nil
+	}
+
+	var b strings.Builder
+	tw := tabwriter.NewWriter(&b, 0, 0, tabwriterPadding, ' ', 0)
+
+	fmt.Fprintln(tw, "ID\tPRIORITY\tMODULE\tMESSAGE\tCREATED AT")
+	for _, entry := range src {
+		fmt.Fprintf(
+			tw,
+			"%d\t%s\t%s\t%s\t%s\n",
+			entry.ID,
+			entry.Priority,
+			entry.Module,
+			entry.Message,
+			entry.CreatedAt.Local().Format(time.RFC3339),
+		)
+	}
+
+	if err := tw.Flush(); err != nil {
+		return "", fmt.Errorf("flush tabwriter: %w", err)
+	}
+
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+func (*TableOutput) Webhook(src smsgateway.Webhook) (string, error) {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "ID:\t%s\n", src.ID)
+	fmt.Fprintf(&b, "Event:\t%s\n", src.Event)
+	fmt.Fprintf(&b, "URL:\t%s\n", src.URL)
+
+	if src.DeviceID != nil {
+		fmt.Fprintf(&b, "Device ID:\t%s\n", *src.DeviceID)
+	}
+
+	return b.String(), nil
+}
+
+func (o *TableOutput) Webhooks(src []smsgateway.Webhook) (string, error) {
+	if len(src) == 0 {
+		return EmptyResult, nil
+	}
+
+	var b strings.Builder
+	tw := tabwriter.NewWriter(&b, 0, 0, tabwriterPadding, ' ', 0)
+
+	fmt.Fprintln(tw, "ID\tEVENT\tURL\tDEVICE ID")
+	for _, w := range src {
+		deviceID := ""
+		if w.DeviceID != nil {
+			deviceID = *w.DeviceID
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", w.ID, w.Event, w.URL, deviceID)
+	}
+
+	if err := tw.Flush(); err != nil {
+		return "", fmt.Errorf("flush tabwriter: %w", err)
+	}
+
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+func (*TableOutput) Success() (string, error) {
+	return "Success", nil
+}
+
+var _ Renderer = (*TableOutput)(nil)

--- a/internal/core/output/text.go
+++ b/internal/core/output/text.go
@@ -73,7 +73,7 @@ func (*TextOutput) MessageState(src smsgateway.MessageState) (string, error) {
 
 func (*TextOutput) Logs(src []smsgateway.LogEntry) (string, error) {
 	if len(src) == 0 {
-		return "Empty result", nil
+		return EmptyResult, nil
 	}
 
 	builder := strings.Builder{}
@@ -126,7 +126,7 @@ func (*TextOutput) Webhook(src smsgateway.Webhook) (string, error) {
 // Returns the formatted string and any error encountered during formatting.
 func (o *TextOutput) Webhooks(src []smsgateway.Webhook) (string, error) {
 	if len(src) == 0 {
-		return "Empty result", nil
+		return EmptyResult, nil
 	}
 
 	builder := strings.Builder{}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new **`table`** option to the CLI **`--format`** flag, rendering message state, logs, and webhook details in a structured, human-readable tabular layout (including relevant status and device information).

* **Documentation**
  * Updated the README “Output Formats” section and added a new **Table** example showing the expected columns and formatting.

* **Improvements**
  * Standardized how empty **logs** and **webhooks** are displayed for consistent “empty result” messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->